### PR TITLE
상대 프로필 페이지에서 일촌 수락 대기중 인터페이스 수정

### DIFF
--- a/frontend/src/styles/ProfilePage/ProfileOther.css
+++ b/frontend/src/styles/ProfilePage/ProfileOther.css
@@ -83,6 +83,11 @@
   min-width: 50px;
 }
 
+.to-disabled-button {
+  background-color: #a8a8a8;
+  border: #a8a8a8;
+}
+
 .profileOther-profile-one_degree_count {
   display: flex;
   font-size: 13.714px; /* 1촌 정보 텍스트 크기 */


### PR DESCRIPTION
- 상대 프로필 페이지에서 일촌 신청이 대기 중인 경우, 일촌 신청 버튼 => 수락 대기로 변경
- 수락 대기 상태에서 버튼 클릭 시 인터페이스 활성화 안되도록 수정
- 수정한 파일은 다음과 같습니다.
> {PROJECT_ROOT}/frontend/src/pages/ProfilePage/ProfileOther.jsx
> {PROJECT_ROOT}/frontend/src/styles/ProfilePage/ProfileOther.css